### PR TITLE
remove role from nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <p aria-hidden="true"><em>Let's care more about web accessibility</em></p>
       </a>
     </div>
-    <nav class="c-nav" role="navigation">
+    <nav class="c-nav">
       <ul>
         {% for link in site.links %}
              {% if link.title == "FAQs" %}


### PR DESCRIPTION
No need for this, a nav gets `role="navigation"` automatically